### PR TITLE
Refactor Connection model findAllConnection method

### DIFF
--- a/models/connection.model.js
+++ b/models/connection.model.js
@@ -41,7 +41,6 @@ class Connection {
             $unwind: "$user2",
         },
     ]).toArray();
-    console.log("🚀 ~ Connection ~ findAllConnecntion ~ connections:", connections)
 
     const result = connections.map((connection) => {
         const user = type === "user1" ? connection.user2 : connection.user1;


### PR DESCRIPTION
Remove unnecessary console.log statement in the findAllConnection method of the Connection model. This statement was printing the connections array to the console, but it is no longer needed. Removing it improves the code readability and performance.